### PR TITLE
feat: oauth2 로그인 성공 시 기존 회원을 판별하여 로그인 응답 값 리턴

### DIFF
--- a/src/main/java/itstime/shootit/greme/oauth/dto/response/LoginResponse.java
+++ b/src/main/java/itstime/shootit/greme/oauth/dto/response/LoginResponse.java
@@ -1,5 +1,6 @@
 package itstime.shootit.greme.oauth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class LoginResponse {
+    @Schema(description = "기존 회원인지 판별 => true(기존회원) / false(최초 로그인)")
+    private Boolean isExistingUser;
+
+    @Schema(description = "이메일")
     private String email;
-    //유저에 대한 각종 정보들
+
+    @Schema(description = "액세스 토큰 => 기존 회원일 때 토큰 발급")
+    private String accessToken;
+
+    //추후 홈 피드에 관련한 데이터 추가해야 함
 }

--- a/src/main/java/itstime/shootit/greme/oauth/presentation/Oauth2Controller.java
+++ b/src/main/java/itstime/shootit/greme/oauth/presentation/Oauth2Controller.java
@@ -23,7 +23,7 @@ public class Oauth2Controller {
     public LoginResponse login(
             @RequestHeader("accessToken") String accessToken,
             @RequestParam("domain") String domain) {
-        return oAuth2Service.findEmailByAccessToken(domain, accessToken);
+        return oAuth2Service.loginByAccessToken(domain, accessToken);
     }
 
 }

--- a/src/main/java/itstime/shootit/greme/user/infrastructure/UserRepository.java
+++ b/src/main/java/itstime/shootit/greme/user/infrastructure/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
 }


### PR DESCRIPTION
## Description
- oauth2 로그인 성공 시 기존 회원이면 jwt를 주고 회원이 아니라면 jwt를 null로 응답한다.

## Note
- 추후 기존 회원이라면 응답 값으로 홈 피드에 관련한 데이터 추가해야 함

#18 