### PR TITLE
feat : 회원탈퇴

### DIFF
--- a/src/main/java/itstime/shootit/greme/challenge/application/ChallengeService.java
+++ b/src/main/java/itstime/shootit/greme/challenge/application/ChallengeService.java
@@ -133,4 +133,11 @@ public class ChallengeService {
                 .summaryRes(challengeSummary).build();
 
     }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void numDeleted(List<Long> challengeId) {
+        for (Long id : challengeId) {
+            challengeRepository.findById(id).get().downNum();  // 참여 인원 -1
+        }
+    }
 }

--- a/src/main/java/itstime/shootit/greme/challenge/application/ChallengeUserService.java
+++ b/src/main/java/itstime/shootit/greme/challenge/application/ChallengeUserService.java
@@ -1,9 +1,13 @@
 package itstime.shootit.greme.challenge.application;
 
+import itstime.shootit.greme.challenge.domain.ChallengeUser;
 import itstime.shootit.greme.challenge.infrastructure.ChallengeUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -14,5 +18,16 @@ public class ChallengeUserService {
     @Transactional(readOnly = true)
     public boolean existsByUserId(Long user_id) {
         return challengeUserRepository.existsByUserId(user_id);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public List<Long> getAllJoinId(Long userId) {  // 유저 id로 참여하고 있는 챌린지 id 모두 가져오기
+        List<ChallengeUser> allByUserId = challengeUserRepository.findAllByUserId(userId);
+        List<Long> joinId = new ArrayList<>();
+
+        for (ChallengeUser challengeUser : allByUserId) {
+            joinId.add(challengeUser.getId());
+        }
+        return joinId;
     }
 }

--- a/src/main/java/itstime/shootit/greme/challenge/domain/Challenge.java
+++ b/src/main/java/itstime/shootit/greme/challenge/domain/Challenge.java
@@ -35,19 +35,8 @@ public class Challenge extends BaseEntity {
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL)
     private List<ChallengeUser> challengeUsers;
 
-//    @Transient
-//    private int res;
-//
-//    public int calRes(Date date) throws ParseException {
-//        String todayFm = new SimpleDateFormat("yyyy-MM-dd").format(new Date(System.currentTimeMillis()));  // 현재 날짜
-//        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-//        Date Dday = new Date(String.valueOf(dateFormat.parse(String.valueOf(getDeadline().getTime()))));
-//        Date today = new Date(String.valueOf(dateFormat.parse(todayFm)));
-//
-//        long calculate = Dday.getTime() - today.getTime();
-//        int Days = (int) (calculate / (24*60*60*1000));
-//        System.out.println(Days);
-//        return Days;
-//    }
+    public void downNum() {
+        this.num -= 1;
+    }
 
 }

--- a/src/main/java/itstime/shootit/greme/challenge/infrastructure/ChallengeRepository.java
+++ b/src/main/java/itstime/shootit/greme/challenge/infrastructure/ChallengeRepository.java
@@ -3,7 +3,9 @@ package itstime.shootit.greme.challenge.infrastructure;
 import itstime.shootit.greme.challenge.domain.Challenge;
 import itstime.shootit.greme.challenge.dto.response.GetChallengeSummaryRes;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
@@ -13,4 +15,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findById(Long challengeId);
 
     GetChallengeSummaryRes findById(Long challengeId, Class<GetChallengeSummaryRes> getChallengeSummaryResClass);
+
+    @Query(value = "UPDATE challenge c SET c.num = c.num -1 WHERE c.id in :challengeIds", nativeQuery = true)
+    void numDeleted(List<Long> challengeIds);
 }

--- a/src/main/java/itstime/shootit/greme/challenge/infrastructure/ChallengeUserRepository.java
+++ b/src/main/java/itstime/shootit/greme/challenge/infrastructure/ChallengeUserRepository.java
@@ -23,6 +23,8 @@ public interface ChallengeUserRepository extends JpaRepository<ChallengeUser, Lo
     List<GetChallengeSummaryRes> findRecentJoinChallenge(Long userId);  // 이번달에 참여한 챌린지
 
     ChallengeUser findByChallengeIdAndUserId(Long challengeId, Long userId);  // 참여하는 챌린지인지
+
+    List<ChallengeUser> findAllByUserId(Long userId);
     boolean existsByChallengeIdAndUserId(Long challengeId, Long userId);  // 참여하는 챌린지인지
 
     @Query(value = "SELECT c.id, c.title FROM challenge c LEFT OUTER JOIN challenge_user cu on c.c_id = cu.challenge_id " +

--- a/src/main/java/itstime/shootit/greme/common/error/dto/ErrorMessage.java
+++ b/src/main/java/itstime/shootit/greme/common/error/dto/ErrorMessage.java
@@ -12,7 +12,8 @@ public enum ErrorMessage {
     FAIL_SIGN_UP(HttpStatus.UNPROCESSABLE_ENTITY, "회원가입에 실패하였습니다"),
     NOT_EXIST_USER(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     FAIL_ADD_CHALLENGE(HttpStatus.UNPROCESSABLE_ENTITY, "챌린지 등록에 실패하였습니다."),
-    NOT_EXIST_POST(HttpStatus.NOT_FOUND,"존재하지 않는 다이어리입니다.");
+    NOT_EXIST_POST(HttpStatus.NOT_FOUND,"존재하지 않는 다이어리입니다."),
+    USER_ALREADY_DELETED(HttpStatus.ALREADY_REPORTED, "이미 탈퇴된 회원입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/itstime/shootit/greme/post/application/PostService.java
+++ b/src/main/java/itstime/shootit/greme/post/application/PostService.java
@@ -25,12 +25,14 @@ import itstime.shootit.greme.user.domain.User;
 import itstime.shootit.greme.user.exception.NotExistUserException;
 import itstime.shootit.greme.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -157,4 +159,16 @@ public class PostService {
     public List<PostInfo> findBySearch(String search) {
         return postRepository.findByContentContainingOrHashtagContaining(search, search);
     }
+
+    @Transactional(readOnly = true)
+    public List<Post> getAllPosts(User user) {
+        return postRepository.findAllByUser(user);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void deleteAllPosts(User user) {
+        postRepository.deleteAll(getAllPosts(user));
+        log.info("해당 유저의 다이어리가 모두 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/itstime/shootit/greme/post/infrastructure/PostRepository.java
+++ b/src/main/java/itstime/shootit/greme/post/infrastructure/PostRepository.java
@@ -37,4 +37,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<PostInfoQuery> findAllByUserOrderByIdDesc(@Param("user_id") Long user_id);
 
     List<PostInfo> findByContentContainingOrHashtagContaining(String content, String hashtag);
+
+    List<Post> findAllByUser(User user);
+
 }

--- a/src/main/java/itstime/shootit/greme/user/application/UserService.java
+++ b/src/main/java/itstime/shootit/greme/user/application/UserService.java
@@ -1,5 +1,8 @@
 package itstime.shootit.greme.user.application;
 
+import itstime.shootit.greme.challenge.application.ChallengeService;
+import itstime.shootit.greme.challenge.application.ChallengeUserService;
+import itstime.shootit.greme.post.application.PostService;
 import itstime.shootit.greme.user.domain.Interest;
 import itstime.shootit.greme.user.domain.InterestType;
 import itstime.shootit.greme.user.domain.User;
@@ -9,19 +12,27 @@ import itstime.shootit.greme.user.dto.request.UserInfoReq;
 import itstime.shootit.greme.user.exception.ExistsUsernameException;
 import itstime.shootit.greme.user.exception.FailSignUpException;
 import itstime.shootit.greme.user.exception.NotExistUserException;
+import itstime.shootit.greme.user.exception.USER_ALREADY_DELETED;
 import itstime.shootit.greme.user.infrastructure.InterestRepository;
 import itstime.shootit.greme.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final InterestRepository interestRepository;
+    private final PostService postService;
+    private final ChallengeUserService challengeUserService;
+    private final ChallengeService challengeService;
 
     public void checkExistsUsername(String username) {
         if (userRepository.existsByUsername(username)) {
@@ -35,6 +46,7 @@ public class UserService {
             userRepository.save(User.builder()
                     .email(signUpReq.getEmail())
                     .username(signUpReq.getUsername())
+                    .activated(true)
                     .build());
         } catch (Exception e) {
             throw new FailSignUpException();
@@ -70,5 +82,22 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public User getUserInfo(String email) {
+        return userRepository.findByEmail(email).orElseThrow(NotExistUserException::new);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void deleteUser(String email) {
+        try {
+            User user = getUserInfo(email).setActiveFalse();  // activated값 false로
+            postService.deleteAllPosts(user);  // 해당 유저가 작성한 post 모두 삭제
+
+            List<Long> allJoinId = challengeUserService.getAllJoinId(user.getId());  // 유저 id로 참여하고 있는 챌린지 id 모두 가져오기
+            challengeService.numDeleted(allJoinId);  // 해당 유저가 참여하는 챌린지 인원 -1
+            log.info("email : {} 유저가 탈퇴했습니다.", user.getEmail());
+        } catch (Exception ignored) {
+            throw new USER_ALREADY_DELETED();
+        }
+    }
 
 }

--- a/src/main/java/itstime/shootit/greme/user/application/UserService.java
+++ b/src/main/java/itstime/shootit/greme/user/application/UserService.java
@@ -13,7 +13,7 @@ import itstime.shootit.greme.user.dto.request.UserInfoReq;
 import itstime.shootit.greme.user.exception.ExistsUsernameException;
 import itstime.shootit.greme.user.exception.FailSignUpException;
 import itstime.shootit.greme.user.exception.NotExistUserException;
-import itstime.shootit.greme.user.exception.USER_ALREADY_DELETED;
+import itstime.shootit.greme.user.exception.UserAlreadyDeleted;
 import itstime.shootit.greme.user.infrastructure.InterestRepository;
 import itstime.shootit.greme.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -99,7 +98,7 @@ public class UserService {
             challengeRepository.numDeleted(allJoinId);  // 쿼리문으로 챌린지 인원 1씩 감소
             log.info("email : {} 유저가 탈퇴했습니다.", user.getEmail());
         } catch (Exception ignored) {
-            throw new USER_ALREADY_DELETED();
+            throw new UserAlreadyDeleted();
         }
     }
 

--- a/src/main/java/itstime/shootit/greme/user/application/UserService.java
+++ b/src/main/java/itstime/shootit/greme/user/application/UserService.java
@@ -2,6 +2,7 @@ package itstime.shootit.greme.user.application;
 
 import itstime.shootit.greme.challenge.application.ChallengeService;
 import itstime.shootit.greme.challenge.application.ChallengeUserService;
+import itstime.shootit.greme.challenge.infrastructure.ChallengeRepository;
 import itstime.shootit.greme.post.application.PostService;
 import itstime.shootit.greme.user.domain.Interest;
 import itstime.shootit.greme.user.domain.InterestType;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 public class UserService {
     private final UserRepository userRepository;
     private final InterestRepository interestRepository;
+    private final ChallengeRepository challengeRepository;
     private final PostService postService;
     private final ChallengeUserService challengeUserService;
     private final ChallengeService challengeService;
@@ -93,7 +95,8 @@ public class UserService {
             postService.deleteAllPosts(user);  // 해당 유저가 작성한 post 모두 삭제
 
             List<Long> allJoinId = challengeUserService.getAllJoinId(user.getId());  // 유저 id로 참여하고 있는 챌린지 id 모두 가져오기
-            challengeService.numDeleted(allJoinId);  // 해당 유저가 참여하는 챌린지 인원 -1
+//            challengeService.numDeleted(allJoinId);  // 해당 유저가 참여하는 챌린지 인원 -1
+            challengeRepository.numDeleted(allJoinId);  // 쿼리문으로 챌린지 인원 1씩 감소
             log.info("email : {} 유저가 탈퇴했습니다.", user.getEmail());
         } catch (Exception ignored) {
             throw new USER_ALREADY_DELETED();

--- a/src/main/java/itstime/shootit/greme/user/domain/User.java
+++ b/src/main/java/itstime/shootit/greme/user/domain/User.java
@@ -3,7 +3,6 @@ package itstime.shootit.greme.user.domain;
 import itstime.shootit.greme.challenge.domain.ChallengeUser;
 import itstime.shootit.greme.user.BaseEntity;
 import itstime.shootit.greme.user.Gender;
-import itstime.shootit.greme.user.exception.USER_ALREADY_DELETED;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/itstime/shootit/greme/user/domain/User.java
+++ b/src/main/java/itstime/shootit/greme/user/domain/User.java
@@ -3,6 +3,7 @@ package itstime.shootit.greme.user.domain;
 import itstime.shootit.greme.challenge.domain.ChallengeUser;
 import itstime.shootit.greme.user.BaseEntity;
 import itstime.shootit.greme.user.Gender;
+import itstime.shootit.greme.user.exception.USER_ALREADY_DELETED;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +46,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<ChallengeUser> challengeUsers;
 
+    private boolean activated;
+
     public void updateGender(Integer genderType) {
         switch (genderType){
             case 0:
@@ -65,6 +68,14 @@ public class User extends BaseEntity {
 
     public void updatePurpose(String purpose){
         this.purpose=purpose;
+    }
+
+    public User setActiveFalse() throws Exception {
+        if (this.activated) {
+            throw new Exception();
+        }
+        this.activated = false;
+        return this;
     }
 
 }

--- a/src/main/java/itstime/shootit/greme/user/exception/USER_ALREADY_DELETED.java
+++ b/src/main/java/itstime/shootit/greme/user/exception/USER_ALREADY_DELETED.java
@@ -1,0 +1,11 @@
+package itstime.shootit.greme.user.exception;
+
+import itstime.shootit.greme.common.error.dto.ErrorMessage;
+import itstime.shootit.greme.common.error.exception.BusinessException;
+
+public class USER_ALREADY_DELETED extends BusinessException {
+
+    public USER_ALREADY_DELETED() {
+        super(ErrorMessage.USER_ALREADY_DELETED);
+    }
+}

--- a/src/main/java/itstime/shootit/greme/user/exception/UserAlreadyDeleted.java
+++ b/src/main/java/itstime/shootit/greme/user/exception/UserAlreadyDeleted.java
@@ -3,9 +3,9 @@ package itstime.shootit.greme.user.exception;
 import itstime.shootit.greme.common.error.dto.ErrorMessage;
 import itstime.shootit.greme.common.error.exception.BusinessException;
 
-public class USER_ALREADY_DELETED extends BusinessException {
+public class UserAlreadyDeleted extends BusinessException {
 
-    public USER_ALREADY_DELETED() {
+    public UserAlreadyDeleted() {
         super(ErrorMessage.USER_ALREADY_DELETED);
     }
 }

--- a/src/main/java/itstime/shootit/greme/user/presentation/UserController.java
+++ b/src/main/java/itstime/shootit/greme/user/presentation/UserController.java
@@ -93,4 +93,16 @@ public class UserController {
     }
 
 
+    @Operation(summary = "회원 탈퇴하기", parameters = {@Parameter(name = "accessToken", description = "액세스 토큰"),
+            @Parameter(name = "userId", description = "유저 id값")})
+    @PatchMapping("{userId}")
+    public ResponseEntity<Void> deleteUser(@PathVariable("userId") Long userId, @RequestHeader("accessToken") String accessToken){
+        userService.deleteUser(jwtTokenProvider.getEmail(accessToken));
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+
+    }
+
+
 }


### PR DESCRIPTION
## Description
- 회원 탈퇴처리를 위한 activated 필드 추가
- 회원 탈퇴시 activated가 false로 세팅
- 유저가 작성한 post 전부 삭제 및 참여 중이던 챌린지 인원 1씩 감소
- 회원 탈퇴 부분 로그 작성

## Note
- 이미 탈퇴한 회원이라면 USER_ALREADY_DELETED가 터져야 하는데 예외가 안터진다.

close #67 
